### PR TITLE
Support ruby 2.5

### DIFF
--- a/lib/random_multivariate_normal.rb
+++ b/lib/random_multivariate_normal.rb
@@ -32,17 +32,21 @@ class RandomMultivariateNormal
     raise ArgumentError.new('Not symmetric matrix') unless mat.symmetric?
     raise ArgumentError.new('Not positive definite matrix') unless mat.eigen.d.each(:diagonal).all?{|d| d > 0.0}
 
-    l = Matrix.zero(mat.row_size)
+    l = array_as_zero_matrix(mat.row_size)
     mat.each_with_index do |e, row, col|
       lij = if row == col
-              Math.sqrt(mat[col, col] - col.times.inject(0){|sum, j| sum + (l[col, j] ** 2)})
+              Math.sqrt(mat[col, col] - col.times.inject(0){|sum, j| sum + (l[col][j] ** 2)})
             elsif row > col
-              (1.0/l[col, col]) * (mat[row, col] - col.times.inject(0){|sum, j| sum + l[row, j] * l[col, j]})
+              (1.0/l[col][col]) * (mat[row, col] - col.times.inject(0){|sum, j| sum + l[row][j] * l[col][j]})
             else
               0.0
             end
-      l[row, col] = lij
+      l[row][col] = lij
     end
-    l
+    Matrix[*l]
+  end
+
+  def array_as_zero_matrix(size)
+    Array.new(size) { Array.new(size, 0) }
   end
 end

--- a/lib/random_multivariate_normal/version.rb
+++ b/lib/random_multivariate_normal/version.rb
@@ -1,3 +1,3 @@
 class RandomMultivariateNormal
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/test/random_multivariate_normal_test.rb
+++ b/test/random_multivariate_normal_test.rb
@@ -15,8 +15,9 @@ class RandomMultivariateNormalTest < Minitest::Test
   def test_that_it_raises_argument_error_if_cov_is_not_symmetric
     dim = 3
     mean = Vector.zero(dim)
-    cov  = Matrix.I(dim)
-    cov[0,1] = 1
+    cov  = Matrix.I(dim).to_a
+    cov[0][1] = 1
+    cov = Matrix[*cov]
 
     assert_raises(ArgumentError) do
       ::RandomMultivariateNormal.new.rand(mean, cov)


### PR DESCRIPTION
This PR provides support for Ruby 2.5 which dose not have Matrix#[]= method.

Currently, NoMethodError occurs in random_multivariate_normal#cholesky_foctor when it runs on Ruby 2.5.

```sh
RandomMultivariateNormalTest#test_that_it_can_get_correct_cholesky_foctor:
NoMethodError: private method `[]=' called for Matrix[[0, 0, 0], [0, 0, 0], [0, 0, 0]]:Matrix
    
github.com/monochromegane/random_multivariate_normal/lib/random_multivariate_normal.rb:44:in `block in cholesky_foctor'
...
```

So, this PR fix this issue by using array only while it needs to change the value.
The result type remains Matrix.